### PR TITLE
Mass workarounds

### DIFF
--- a/custom_components/lastfm_scrobbler/media_player.py
+++ b/custom_components/lastfm_scrobbler/media_player.py
@@ -148,7 +148,7 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
                         "Won't use album info from MASS radio playback - "
                         "it displays the name of the radio station"
                     )
-                    self._album = ""
+                    self._album = None
                 else:
                     self._album = player.attributes.get("media_album_name")
                 media_duration = player.attributes.get("media_duration")

--- a/custom_components/lastfm_scrobbler/media_player.py
+++ b/custom_components/lastfm_scrobbler/media_player.py
@@ -123,7 +123,11 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
                 if (
                     self._artist
                     and player.attributes.get("mass_player_type")
-                    and " / " in self._artist
+                    and "/" in self._artist
+                    and self._artist.lower()
+                    not in [
+                        "ac/dc",
+                    ]
                 ):
                     # Music Assistant lists multiple artists from spotify (and maybe other sources)
                     # separated by slashes ("/"). That's unusual and will mess up scrobbles.
@@ -134,7 +138,7 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
                         "Remove slashed multi-artists from MASS artist data (%s)",
                         self._artist,
                     )
-                    self._artist = self._artist.split(" / ")[0]
+                    self._artist = self._artist.split("/")[0]
                     _LOGGER.debug("Resulting artist: %s", self._artist)
 
                 if (


### PR DESCRIPTION
I could swear these slashes were surrounded by spaces before... Now that they apparently aren't, we need a workaround within the workaround for AC/DC... I couldn't find any other bands carrying a slash within their names.

This is exceptionally dumb coding, but it's the only way I see to deal with the artist data supplied by Music Assistant. Alternatives would be blocking Music Assistant from this integration or having a messed-up scrobble database.