### PR TITLE
Add binary_sensor to check entites

### DIFF
--- a/custom_components/lastfm_scrobbler/config_flow.py
+++ b/custom_components/lastfm_scrobbler/config_flow.py
@@ -44,7 +44,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_CHECK_ENTITY, default=[]): EntitySelector(
             EntitySelectorConfig(
                 filter=EntityFilterSelectorConfig(
-                    domain=["person", "input_boolean", "switch"]
+                    domain=["person", "input_boolean", "switch", "binary_sensor"]
                 ),
                 multiple=True,
             )
@@ -150,7 +150,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): EntitySelector(
                     EntitySelectorConfig(
                         filter=EntityFilterSelectorConfig(
-                            domain=["person", "input_boolean", "switch"]
+                            domain=["person", "input_boolean", "switch", "binary_sensor"]
                         ),
                         multiple=True,
                     )

--- a/custom_components/lastfm_scrobbler/media_player.py
+++ b/custom_components/lastfm_scrobbler/media_player.py
@@ -92,7 +92,7 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
             entity = self.hass.states.get(player_entity_id)
             _LOGGER.debug("Checking %s", entity.entity_id)
 
-            if entity.domain in ["input_boolean", "switch"]:
+            if entity.domain in ["input_boolean", "switch", "binary_sensor"]:
                 if entity.state == "on":
                     _LOGGER.debug("%s is on! Agreed to scrobble", entity.entity_id)
                 else:


### PR DESCRIPTION
Thanks for this very good component and the latest developments, I really appreciate it!

Just small PR which aims to add `binary_sensor` in the check entities to trigger scrobbling conditionally. Without this, you have to go through a sensor that allows you to change the type of `binary_sensor` to switch.
Tested and validated on my instance.