### PR TITLE
Fix artist/title returned as list by Emby/Jellyfin

### DIFF
--- a/custom_components/lastfm_scrobbler/media_player.py
+++ b/custom_components/lastfm_scrobbler/media_player.py
@@ -223,6 +223,13 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
             if player is not None and player.state == STATE_PLAYING:
                 self._artist = player.attributes.get("media_artist")
                 self._current_track = player.attributes.get("media_title")
+
+                # Handle cases where media_artist/title is returned as a list (Emby, Jellyfin)
+                if isinstance(self._artist, list) and self._artist:
+                    self._artist = self._artist[0]
+                if isinstance(self._current_track, list) and self._current_track:
+                    self._current_track = self._current_track[0]
+
                 if not self._artist or not self._current_track:
                     # no scrobbling without artist and track info -
                     # go straight to the next player instead of doing more, ultimately useless work


### PR DESCRIPTION
## Summary
Fixes #17 - Emby scrobbles has Artist in brackets

Some media players (Emby, Jellyfin) return `media_artist` and `media_title` as a Python list `['Artist Name']` instead of a string. This caused brackets to appear in scrobbles like `['Laura Veirs']`.

**Fix:** Extract first element if the attribute is a list.

May also help with #18 (wrong artist "N" instead of "Guns N' Roses") - waiting for user feedback.

## Test plan
- [x] Simulated list format by wrapping artist in `[artist]`
- [x] Verified scrobble works correctly with "Cat Stevens"
- [x] Verified scrobble works correctly with "Guns N' Roses" (apostrophe in name)