### PR TITLE
Fix concurrent double scrobbles with a lock (#16)

### DIFF
--- a/custom_components/lastfm_scrobbler/media_player.py
+++ b/custom_components/lastfm_scrobbler/media_player.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import logging
+import threading
 import time
 
 import pylast
@@ -80,6 +81,11 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
         self._duration = None
         self._now_playing = None
         self._last_scrobbled_track = None
+        # update() runs in Home Assistant's sync worker thread pool, so several
+        # cycles can overlap. This lock serializes the check-then-scrobble
+        # section to prevent the same track being scrobbled multiple times by
+        # concurrent updates (issue #16).
+        self._scrobble_lock = threading.Lock()
         self._lastfm_network = lastfm_network
         self._media_players = media_players
         self._check_entities = check_entities
@@ -138,27 +144,32 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
 
     def scrobble(self):
         """Scrobble the current playing track to Last.fm."""
-        if self._last_scrobbled_track == (
-            self._artist,
-            self._current_track,
-            self._album,
-        ):
-            _LOGGER.info(
-                "Already scrobbled %s by %s, skipping",
-                self._current_track,
+        # Serialize the whole check-mark-send section: update() runs in HA's
+        # thread pool and cycles can overlap, so without this lock two
+        # concurrent updates could both pass the "already scrobbled" check
+        # before either marks the track, producing duplicate scrobbles (#16).
+        with self._scrobble_lock:
+            if self._last_scrobbled_track == (
                 self._artist,
+                self._current_track,
+                self._album,
+            ):
+                _LOGGER.info(
+                    "Already scrobbled %s by %s, skipping",
+                    self._current_track,
+                    self._artist,
+                )
+                return None
+
+            timestamp = int(time.time())
+
+            # Mark as scrobbled BEFORE the API call to prevent duplicates on
+            # timeout. Last.fm rejects duplicates with the same timestamp anyway.
+            self._last_scrobbled_track = (
+                self._artist,
+                self._current_track,
+                self._album,
             )
-            return None
-
-        timestamp = int(time.time())
-
-        # Mark as scrobbled BEFORE the API call to prevent duplicates on timeout
-        # Last.fm rejects duplicates with the same timestamp anyway
-        self._last_scrobbled_track = (
-            self._artist,
-            self._current_track,
-            self._album,
-        )
 
         try:
             self._lastfm_network.scrobble(


### PR DESCRIPTION
## Problem

Issue #16 reported tracks being scrobbled 2-4 times. The v1.4.0 fix
addressed duplicates caused by **network timeouts**, but a user still
reported double scrobbles on v1.4.0 (worked around by setting the
scrobble point to 95%).

## Root cause

`update()` is a synchronous entity method, so Home Assistant runs it in
its sync worker thread pool. Cycles can overlap, and there was **no
synchronization** around the check-then-mark logic in `scrobble()`. Two
concurrent updates could both pass the "already scrobbled" check before
either marked the track, each firing a scrobble. Raising the scrobble
threshold to 95% only shrank the race window, which is why it "fixed" it.

## Fix

Wrap the check-mark section of `scrobble()` in a `threading.Lock`, making
it atomic. The network call stays **outside** the lock so a slow HTTP
request doesn't block other update cycles.

Verified with a unit test: 10 concurrent threads on the same track →
1 scrobble with the lock, ~5 without it (reproducing the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)