### PR TITLE
Add Music Assistant provider filter and "all players" mode

### DIFF
--- a/custom_components/lastfm_scrobbler/config_flow.py
+++ b/custom_components/lastfm_scrobbler/config_flow.py
@@ -15,42 +15,147 @@ from homeassistant.helpers.selector import (
     EntityFilterSelectorConfig,
     EntitySelector,
     EntitySelectorConfig,
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
 )
 
 from .const import (
+    CONF_ALL_PLAYERS,
     CONF_API_SECRET,
     CONF_CHECK_ENTITY,
+    CONF_PROVIDER_FILTER_LIST,
+    CONF_PROVIDER_FILTER_MODE,
     CONF_SCROBBLE_PERCENTAGE,
     CONF_SESSION_KEY,
     CONF_UPDATE_NOW_PLAYING,
     DOMAIN,
+    MASS_DOMAIN,
+    PROVIDER_FILTER_MODES,
+    PROVIDER_FILTER_OFF,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_NAME, default="My Scrobbler"): str,
-        vol.Required(CONF_API_KEY): str,
-        vol.Required(CONF_API_SECRET): str,  # API_SECRET
-        vol.Required(CONF_SESSION_KEY): str,  # SESSION_KEY
-        vol.Required(CONF_SCROBBLE_PERCENTAGE, default=50): int,
-        vol.Required(CONF_UPDATE_NOW_PLAYING, default=False): bool,
-        vol.Required(CONF_ENTITY_ID): EntitySelector(
-            EntitySelectorConfig(
-                filter=EntityFilterSelectorConfig(domain="media_player"), multiple=True
-            )
-        ),
-        vol.Optional(CONF_CHECK_ENTITY, default=[]): EntitySelector(
-            EntitySelectorConfig(
-                filter=EntityFilterSelectorConfig(
-                    domain=["person", "input_boolean", "switch", "binary_sensor"]
-                ),
+
+def _get_mass_providers(hass):
+    """Return the list of configured Music Assistant provider instances.
+
+    Reads the providers straight from the running Music Assistant client kept
+    by the official integration (entry.runtime_data.mass). Returns a list of
+    (instance_id, label) tuples. Returns an empty list on any failure so the
+    caller can gracefully fall back to manual text entry.
+    """
+    providers: list[tuple[str, str]] = []
+    try:
+        for entry in hass.config_entries.async_entries(MASS_DOMAIN):
+            mass = getattr(entry, "runtime_data", None)
+            mass = getattr(mass, "mass", None)
+            if mass is None:
+                continue
+            for prov in mass.providers:
+                # Only music providers can appear as the source of a played
+                # track (in media_content_id). Player/metadata/plugin providers
+                # never cause scrobbles, so we keep the list short and relevant.
+                prov_type = getattr(prov, "type", None)
+                type_value = getattr(prov_type, "value", prov_type)
+                if type_value != "music":
+                    continue
+                label = f"{prov.name} ({prov.domain})"
+                providers.append((prov.instance_id, label))
+    except Exception:  # noqa: BLE001 - never let discovery break the form
+        _LOGGER.debug("Could not read Music Assistant providers", exc_info=True)
+        return []
+    # De-duplicate while keeping order (multiple entries could repeat one)
+    seen: set[str] = set()
+    unique: list[tuple[str, str]] = []
+    for instance_id, label in providers:
+        if instance_id in seen:
+            continue
+        seen.add(instance_id)
+        unique.append((instance_id, label))
+    return unique
+
+
+def _provider_filter_list_field(hass, current):
+    """Build the provider-filter-list schema field.
+
+    Uses a dynamic dropdown pre-filled with the Music Assistant providers when
+    they can be read; otherwise falls back to a free-text multi-entry field so
+    the option stays usable even when Music Assistant is unavailable.
+    """
+    current = current or []
+    providers = _get_mass_providers(hass)
+    if providers:
+        options = [
+            SelectOptionDict(value=instance_id, label=label)
+            for instance_id, label in providers
+        ]
+        # Keep any previously-saved values that are no longer reported by MA
+        # (e.g. a provider that is temporarily offline) so they aren't dropped.
+        known = {instance_id for instance_id, _ in providers}
+        for value in current:
+            if value not in known:
+                options.append(SelectOptionDict(value=value, label=value))
+        return SelectSelector(
+            SelectSelectorConfig(
+                options=options,
+                mode=SelectSelectorMode.DROPDOWN,
                 multiple=True,
+                custom_value=True,
             )
-        ),
-    }
-)
+        )
+    # Fallback: manual entry
+    return TextSelector(TextSelectorConfig(multiple=True))
+
+
+def _provider_filter_mode_field(default=PROVIDER_FILTER_OFF):
+    """Build the provider-filter-mode dropdown field."""
+    return SelectSelector(
+        SelectSelectorConfig(
+            options=PROVIDER_FILTER_MODES,
+            mode=SelectSelectorMode.DROPDOWN,
+            translation_key=CONF_PROVIDER_FILTER_MODE,
+        )
+    )
+
+
+def _build_user_schema(hass):
+    """Build the initial setup schema (with dynamic MA provider list)."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_NAME, default="My Scrobbler"): str,
+            vol.Required(CONF_API_KEY): str,
+            vol.Required(CONF_API_SECRET): str,  # API_SECRET
+            vol.Required(CONF_SESSION_KEY): str,  # SESSION_KEY
+            vol.Required(CONF_SCROBBLE_PERCENTAGE, default=50): int,
+            vol.Required(CONF_UPDATE_NOW_PLAYING, default=False): bool,
+            vol.Required(CONF_ALL_PLAYERS, default=False): bool,
+            vol.Optional(CONF_ENTITY_ID, default=[]): EntitySelector(
+                EntitySelectorConfig(
+                    filter=EntityFilterSelectorConfig(domain="media_player"),
+                    multiple=True,
+                )
+            ),
+            vol.Optional(CONF_CHECK_ENTITY, default=[]): EntitySelector(
+                EntitySelectorConfig(
+                    filter=EntityFilterSelectorConfig(
+                        domain=["person", "input_boolean", "switch", "binary_sensor"]
+                    ),
+                    multiple=True,
+                )
+            ),
+            vol.Required(
+                CONF_PROVIDER_FILTER_MODE, default=PROVIDER_FILTER_OFF
+            ): _provider_filter_mode_field(),
+            vol.Optional(
+                CONF_PROVIDER_FILTER_LIST, default=[]
+            ): _provider_filter_list_field(hass, []),
+        }
+    )
 
 
 class ScrobblerConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -66,6 +171,10 @@ class ScrobblerConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             #Check if all optional fields have defaults values
             user_input.setdefault(CONF_CHECK_ENTITY, [])
+            user_input.setdefault(CONF_PROVIDER_FILTER_MODE, PROVIDER_FILTER_OFF)
+            user_input.setdefault(CONF_PROVIDER_FILTER_LIST, [])
+            user_input.setdefault(CONF_ALL_PLAYERS, False)
+            user_input.setdefault(CONF_ENTITY_ID, [])
             try:
                 pass
             except Exception:
@@ -77,7 +186,9 @@ class ScrobblerConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=_build_user_schema(self.hass),
+            errors=errors,
         )
 
     @staticmethod
@@ -100,10 +211,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
         config = self.hass.data[DOMAIN][self.config_entry.entry_id]
 
-        if user_input is not None:            
+        if user_input is not None:
             #Check if all optional fields have defaults values
             user_input.setdefault(CONF_CHECK_ENTITY, [])
-            
+            user_input.setdefault(CONF_PROVIDER_FILTER_MODE, PROVIDER_FILTER_OFF)
+            user_input.setdefault(CONF_PROVIDER_FILTER_LIST, [])
+            user_input.setdefault(CONF_ALL_PLAYERS, False)
+            user_input.setdefault(CONF_ENTITY_ID, [])
+
             try:
                 pass
             except Exception:
@@ -138,7 +253,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     default=config[CONF_UPDATE_NOW_PLAYING],
                 ): bool,
                 vol.Required(
-                    CONF_ENTITY_ID, default=config[CONF_ENTITY_ID]
+                    CONF_ALL_PLAYERS,
+                    default=config.get(CONF_ALL_PLAYERS, False),
+                ): bool,
+                vol.Optional(
+                    CONF_ENTITY_ID, default=config.get(CONF_ENTITY_ID, [])
                 ): EntitySelector(
                     EntitySelectorConfig(
                         filter=EntityFilterSelectorConfig(domain="media_player"),
@@ -154,6 +273,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         ),
                         multiple=True,
                     )
+                ),
+                vol.Required(
+                    CONF_PROVIDER_FILTER_MODE,
+                    default=config.get(
+                        CONF_PROVIDER_FILTER_MODE, PROVIDER_FILTER_OFF
+                    ),
+                ): _provider_filter_mode_field(),
+                vol.Optional(
+                    CONF_PROVIDER_FILTER_LIST,
+                    default=config.get(CONF_PROVIDER_FILTER_LIST, []),
+                ): _provider_filter_list_field(
+                    self.hass, config.get(CONF_PROVIDER_FILTER_LIST, [])
                 ),
             }
         )

--- a/custom_components/lastfm_scrobbler/const.py
+++ b/custom_components/lastfm_scrobbler/const.py
@@ -6,3 +6,20 @@ CONF_UPDATE_NOW_PLAYING = "update_now_playing"
 CONF_CHECK_ENTITY = "check_entity"
 CONF_API_SECRET = "api_secret"
 CONF_SESSION_KEY = "session_key"
+CONF_PROVIDER_FILTER_MODE = "provider_filter_mode"
+CONF_PROVIDER_FILTER_LIST = "provider_filter_list"
+CONF_ALL_PLAYERS = "all_players"
+
+# Provider filter modes for Music Assistant sources
+PROVIDER_FILTER_OFF = "off"
+PROVIDER_FILTER_BLOCKLIST = "blocklist"
+PROVIDER_FILTER_ALLOWLIST = "allowlist"
+PROVIDER_FILTER_MODES = [
+    PROVIDER_FILTER_OFF,
+    PROVIDER_FILTER_BLOCKLIST,
+    PROVIDER_FILTER_ALLOWLIST,
+]
+
+# Domain of the official Music Assistant integration, used to read the list
+# of configured providers dynamically when building the config/options form.
+MASS_DOMAIN = "music_assistant"

--- a/custom_components/lastfm_scrobbler/media_player.py
+++ b/custom_components/lastfm_scrobbler/media_player.py
@@ -13,12 +13,18 @@ from homeassistant.const import CONF_API_KEY, CONF_ENTITY_ID, CONF_NAME, STATE_P
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    CONF_ALL_PLAYERS,
     CONF_API_SECRET,
     CONF_CHECK_ENTITY,
+    CONF_PROVIDER_FILTER_LIST,
+    CONF_PROVIDER_FILTER_MODE,
     CONF_SCROBBLE_PERCENTAGE,
     CONF_SESSION_KEY,
     CONF_UPDATE_NOW_PLAYING,
     DOMAIN,
+    PROVIDER_FILTER_ALLOWLIST,
+    PROVIDER_FILTER_BLOCKLIST,
+    PROVIDER_FILTER_OFF,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +46,9 @@ async def async_setup_entry(
     check_entities = config[CONF_CHECK_ENTITY]
     scrobble_percentage = config[CONF_SCROBBLE_PERCENTAGE]
     update_now_playing = config[CONF_UPDATE_NOW_PLAYING]
+    provider_filter_mode = config.get(CONF_PROVIDER_FILTER_MODE, PROVIDER_FILTER_OFF)
+    provider_filter_list = config.get(CONF_PROVIDER_FILTER_LIST, [])
+    all_players = config.get(CONF_ALL_PLAYERS, False)
 
     lastfm_network = pylast.LastFMNetwork(
         api_key=api_key, api_secret=api_secret, session_key=session_key
@@ -54,6 +63,9 @@ async def async_setup_entry(
                 check_entities,
                 scrobble_percentage,
                 update_now_playing,
+                provider_filter_mode,
+                provider_filter_list,
+                all_players,
             )
         ]
     )
@@ -70,6 +82,9 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
         check_entities,
         scrobble_percentage,
         update_now_playing,
+        provider_filter_mode=PROVIDER_FILTER_OFF,
+        provider_filter_list=None,
+        all_players=False,
     ) -> None:
         """Initialize the media player entity."""
         self._name = name
@@ -91,6 +106,12 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
         self._check_entities = check_entities
         self._update_now_playing = update_now_playing
         self._scrobble_percentage = scrobble_percentage
+        self._all_players = all_players
+        self._provider_filter_mode = provider_filter_mode
+        # Normalize the filter list once: lowercase, stripped, no empties
+        self._provider_filter_list = [
+            p.strip().lower() for p in (provider_filter_list or []) if p and p.strip()
+        ]
 
     def check_entities(self):
         """Check if all the given check_entities agree to scrobble."""
@@ -118,6 +139,64 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
 
         _LOGGER.debug("All entity checks passed - we can scrobble!")
         return True
+
+    @staticmethod
+    def extract_provider(media_content_id):
+        """Extract the Music Assistant provider from a media_content_id.
+
+        Music Assistant builds item URIs as
+        "<provider_instance_or_domain>://<media_type>/<item_id>",
+        e.g. "tidal--f4QvvBiv://track/123" or "local_audio://track/456".
+        We return both the full instance id and its bare domain (the part
+        before the first "--") so callers can match on either.
+        """
+        if not media_content_id or "://" not in media_content_id:
+            return None, None
+        instance = media_content_id.split("://", 1)[0].strip().lower()
+        if not instance:
+            return None, None
+        # Provider instance ids look like "tidal--f4QvvBiv"; the domain is "tidal".
+        domain = instance.split("--", 1)[0]
+        return instance, domain
+
+    def provider_allowed(self, media_content_id):
+        """Decide whether a track from this provider is allowed to scrobble.
+
+        Only applies to Music Assistant players (those exposing a
+        provider-prefixed media_content_id). Non-MA players, or MA players
+        without a recognizable provider, are always allowed so existing
+        behaviour is preserved.
+        """
+        if self._provider_filter_mode == PROVIDER_FILTER_OFF:
+            return True
+
+        instance, domain = self.extract_provider(media_content_id)
+        if instance is None:
+            # No recognizable provider (non-MA player or missing content id).
+            # Don't block these - the filter only targets MA providers.
+            return True
+
+        # A provider matches the filter list if either its full instance id
+        # or its bare domain is listed (case-insensitive).
+        in_list = instance in self._provider_filter_list or (
+            domain is not None and domain in self._provider_filter_list
+        )
+
+        if self._provider_filter_mode == PROVIDER_FILTER_BLOCKLIST:
+            allowed = not in_list
+        elif self._provider_filter_mode == PROVIDER_FILTER_ALLOWLIST:
+            allowed = in_list
+        else:
+            allowed = True
+
+        if not allowed:
+            _LOGGER.debug(
+                "Provider '%s' (domain '%s') filtered out by %s - skipping",
+                instance,
+                domain,
+                self._provider_filter_mode,
+            )
+        return allowed
 
     def update_now_playing(self):
         """Update the current playing song."""
@@ -221,6 +300,25 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
             )
             return None
 
+    def get_players_to_check(self):
+        """Return the list of media_player entity ids to check this cycle.
+
+        When "all players" is enabled we dynamically look up every
+        media_player entity currently known to Home Assistant (so newly
+        created Music Assistant players are picked up automatically), minus
+        this scrobbler's own entity to avoid checking ourselves. Otherwise we
+        use the user-selected list, preserving its priority order.
+        """
+        if not self._all_players:
+            return self._media_players
+
+        players = [
+            state.entity_id
+            for state in self.hass.states.async_all("media_player")
+            if state.entity_id != self.entity_id
+        ]
+        return players
+
     def update(self):
         """Update the media player entity state."""
         if not self.check_entities():
@@ -228,10 +326,25 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
             return False
         _LOGGER.debug("Entity checks passed - %s now updating", self.name)
         reason_to_break = False
-        for player_entity_id in self._media_players:
+        for player_entity_id in self.get_players_to_check():
             updated_now_playing = False
             player = self.hass.states.get(player_entity_id)
             if player is not None and player.state == STATE_PLAYING:
+                # In "all players" mode we look at every media_player, including
+                # ones that play video (TV, YouTube...). Only scrobble actual
+                # music: skip anything whose content type isn't "music". We only
+                # enforce this when a content type is reported, so players that
+                # don't set it keep their previous behaviour.
+                if self._all_players:
+                    content_type = player.attributes.get("media_content_type")
+                    if content_type is not None and content_type != "music":
+                        _LOGGER.debug(
+                            "Skipping %s: media_content_type is %r, not music",
+                            player.entity_id,
+                            content_type,
+                        )
+                        continue
+
                 self._artist = player.attributes.get("media_artist")
                 self._current_track = player.attributes.get("media_title")
 
@@ -258,6 +371,21 @@ class LastFMScrobblerMediaPlayer(MediaPlayerEntity):
                     player.entity_id,
                 )
                 reason_to_break = True
+
+                # Skip Music Assistant sources the user chose to filter out
+                # (e.g. Tidal, which already scrobbles on its own and would
+                # otherwise cause duplicate scrobbles). We skip both the
+                # "now playing" update and the scrobble for this player, but
+                # still break afterwards so a lower-priority player doesn't
+                # get scrobbled while this one is the active source.
+                if not self.provider_allowed(
+                    player.attributes.get("media_content_id")
+                ):
+                    _LOGGER.info(
+                        "%s is playing from a filtered provider - not scrobbling",
+                        player.entity_id,
+                    )
+                    break
 
                 if (
                     self._artist

--- a/custom_components/lastfm_scrobbler/strings.json
+++ b/custom_components/lastfm_scrobbler/strings.json
@@ -13,7 +13,10 @@
           "scrobble_percentage": "Scrobble after playback of this percentage of track length.",
           "update_now_playing": "Check to also update the \"now playing\" info on last.fm",
           "entity_id": "Select media players to scrobble from (ordered by priority)",
-          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)"
+          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)",
+          "provider_filter_mode": "Music Assistant provider filter",
+          "provider_filter_list": "Music Assistant providers to filter (e.g. Tidal)",
+          "all_players": "Scrobble from ALL media players (ignores the selection below)"
         },
         "description": "Enter credentials according to the README and configure the behaviour of this scrobbler."
       }
@@ -32,9 +35,21 @@
           "scrobble_percentage": "Scrobble after playback of this percentage of track length.",
           "update_now_playing": "Check to also update the \"now playing\" info on last.fm",
           "entity_id": "Select media players to scrobble from (ordered by priority)",
-          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)"
+          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)",
+          "provider_filter_mode": "Music Assistant provider filter",
+          "provider_filter_list": "Music Assistant providers to filter (e.g. Tidal)",
+          "all_players": "Scrobble from ALL media players (ignores the selection below)"
         },
         "description": "Update credentials according to README or change the behaviour of this scrobbler."
+      }
+    }
+  },
+  "selector": {
+    "provider_filter_mode": {
+      "options": {
+        "off": "Off - scrobble every provider",
+        "blocklist": "Block list - scrobble all except the providers below",
+        "allowlist": "Allow list - only scrobble the providers below"
       }
     }
   }

--- a/custom_components/lastfm_scrobbler/translations/en.json
+++ b/custom_components/lastfm_scrobbler/translations/en.json
@@ -13,7 +13,10 @@
           "scrobble_percentage": "Scrobble after playback of this percentage of track length.",
           "update_now_playing": "Check to also update the \"now playing\" info on last.fm",
           "entity_id": "Select media players to scrobble from (ordered by priority)",
-          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)"
+          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)",
+          "provider_filter_mode": "Music Assistant provider filter",
+          "provider_filter_list": "Music Assistant providers to filter (e.g. Tidal)",
+          "all_players": "Scrobble from ALL media players (ignores the selection below)"
         },
         "description": "Enter credentials according to the README and configure the behaviour of this scrobbler."
       }
@@ -32,9 +35,21 @@
           "scrobble_percentage": "Scrobble after playback of this percentage of track length.",
           "update_now_playing": "Check to also update the \"now playing\" info on last.fm",
           "entity_id": "Select media players to scrobble from (ordered by priority)",
-          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)"
+          "check_entity": "Optional: Only scrobble when ALL selected entities are \"positive\" (person=home, switch=on, etc.)",
+          "provider_filter_mode": "Music Assistant provider filter",
+          "provider_filter_list": "Music Assistant providers to filter (e.g. Tidal)",
+          "all_players": "Scrobble from ALL media players (ignores the selection below)"
         },
         "description": "Update credentials according to README or change the behaviour of this scrobbler."
+      }
+    }
+  },
+  "selector": {
+    "provider_filter_mode": {
+      "options": {
+        "off": "Off - scrobble every provider",
+        "blocklist": "Block list - scrobble all except the providers below",
+        "allowlist": "Allow list - only scrobble the providers below"
       }
     }
   }

--- a/custom_components/lastfm_scrobbler/translations/fr.json
+++ b/custom_components/lastfm_scrobbler/translations/fr.json
@@ -13,7 +13,10 @@
           "scrobble_percentage": "Scrobble après lecture de ce pourcentage de la durée du morceau.",
           "update_now_playing": "Cochez pour également mettre à jour l'information \"en cours de lecture\" sur last.fm",
           "entity_id": "Sélectionnez les lecteurs multimédias à scrobbler (classés par priorité)",
-          "check_entity": "Optionnel : Scrobble uniquement lorsque TOUS les entités sélectionnées sont \"positives\" (personne=maison, interrupteur=activé, etc.)"
+          "check_entity": "Optionnel : Scrobble uniquement lorsque TOUS les entités sélectionnées sont \"positives\" (personne=maison, interrupteur=activé, etc.)",
+          "provider_filter_mode": "Filtre de fournisseur Music Assistant",
+          "provider_filter_list": "Fournisseurs Music Assistant à filtrer (ex. Tidal)",
+          "all_players": "Scrobbler depuis TOUS les lecteurs (ignore la sélection ci-dessous)"
         },
         "description": "Entrez les informations d'identification conformément au README et configurez le comportement de ce scrobbler."
       }
@@ -32,9 +35,21 @@
           "scrobble_percentage": "Scrobble après lecture de ce pourcentage de la durée du morceau.",
           "update_now_playing": "Cochez pour également mettre à jour l'information \"en cours de lecture\" sur last.fm",
           "entity_id": "Sélectionnez les lecteurs multimédias à scrobbler (classés par priorité)",
-          "check_entity": "Optionnel : Scrobble uniquement lorsque TOUS les entités sélectionnées sont \"positives\" (personne=maison, interrupteur=activé, etc.)"
+          "check_entity": "Optionnel : Scrobble uniquement lorsque TOUS les entités sélectionnées sont \"positives\" (personne=maison, interrupteur=activé, etc.)",
+          "provider_filter_mode": "Filtre de fournisseur Music Assistant",
+          "provider_filter_list": "Fournisseurs Music Assistant à filtrer (ex. Tidal)",
+          "all_players": "Scrobbler depuis TOUS les lecteurs (ignore la sélection ci-dessous)"
         },
         "description": "Mettez à jour les informations d'identification conformément au README ou modifiez le comportement de ce scrobbler."
+      }
+    }
+  },
+  "selector": {
+    "provider_filter_mode": {
+      "options": {
+        "off": "Désactivé - scrobbler tous les fournisseurs",
+        "blocklist": "Liste de blocage - scrobbler tout sauf les fournisseurs ci-dessous",
+        "allowlist": "Liste d'autorisation - scrobbler uniquement les fournisseurs ci-dessous"
       }
     }
   }


### PR DESCRIPTION
> Stacked on top of #23 (base branch: `fix/issue-16-concurrent-scrobbles`).
> Will retarget to `master` automatically once #23 is merged.

Two related features to control what gets scrobbled when using Music Assistant.

## Provider filter

- New option with **off / blocklist / allowlist** modes.
- Providers are matched from the `media_content_id` prefix. Music Assistant encodes items as `<provider>://<type>/<id>` (e.g. `tidal://track/123`), matching on either the full instance id or the bare domain.
- The config/options form **pre-fills a dropdown** with the Music Assistant music providers, read live from the running integration, and falls back to free-text entry when Music Assistant can't be reached.
- **Primary use case:** stop scrobbling Tidal (which scrobbles on its own) to avoid duplicate scrobbles, while still scrobbling local files.

## "All players" mode

- New **toggle** to watch every `media_player` entity instead of a fixed list, so newly created Music Assistant players are picked up automatically.
- In this mode, players whose `media_content_type` isn't `music` (TV, YouTube, etc.) are skipped, to avoid scrobbling video as if it were music.

## Notes

- Fully backward compatible: both features default to off, existing configs behave exactly as before.
- Translations updated for English and French.
- Tested live against a real Music Assistant instance (Tidal blocked, local/Plex scrobbled, YouTube video skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)